### PR TITLE
avoid testing into the tag reserved memory space

### DIFF
--- a/bare_metal/examples/selftest.c
+++ b/bare_metal/examples/selftest.c
@@ -209,6 +209,8 @@ unsigned long long lfsr64(unsigned long long d) {
 #define VERIFY_DISTANCE 16
 
 int sdram_test() {
+  volatile uint64_t * addr_base = get_ddr_base();
+  uint64_t addr_mask = (get_ddr_size() - 1) >> 3;
   unsigned long waddr = 0;
   unsigned long raddr = 0;
   unsigned long long wkey = 0;
@@ -222,8 +224,8 @@ int sdram_test() {
   while(1) {
     printf("Write block @%lx using key %llx\n", waddr, wkey);
     for(i=0; i<STEP_SIZE; i++) {
-      *(get_ddr_base() + waddr) = wkey;
-      waddr = (waddr + 1) & 0x3ffffff;
+      *(addr_base + waddr) = wkey;
+      waddr = (waddr == addr_mask) ? 0 : waddr + 1;
       wkey = lfsr64(wkey);
     }
     
@@ -232,13 +234,13 @@ int sdram_test() {
     if(distance == VERIFY_DISTANCE) {
       printf("Check block @%lx using key %llx\n", raddr, rkey);
       for(i=0; i<STEP_SIZE; i++) {
-        unsigned long long rd = *(get_ddr_base() + raddr);
+        unsigned long long rd = *(addr_base + raddr);
         if(rkey != rd) {
           printf("Error! key %llx stored @%lx does not match with %llx\n", rd, raddr, rkey);
           error_cnt++;
           exit(1);
         }
-        raddr = (raddr + 1) & 0x3ffffff;
+        raddr = (raddr == addr_mask) ? 0 : raddr + 1;
         rkey = lfsr64(rkey);
         if(error_cnt > 10) exit(1);
       }


### PR DESCRIPTION
The plain code copy from dram.c into selftest.c is not ideal. Is there a way to reduce code duplication?